### PR TITLE
Update kinds and add converters

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -623,6 +623,61 @@ Object {
 }
 `;
 
+exports[`new test 2 ben also fix this 1`] = `
+Object {
+  "classes": Array [
+    Object {
+      "kind": "object",
+      "props": Array [
+        Object {
+          "kind": "object",
+          "props": Array [
+            Object {
+              "key": "bar",
+              "kind": "property",
+              "optional": false,
+              "value": Object {
+                "kind": "string",
+              },
+            },
+          ],
+        },
+        Object {
+          "key": "isDefaultChecked",
+          "kind": "property",
+          "optional": false,
+          "value": Object {
+            "kind": "boolean",
+          },
+        },
+      ],
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`new test ben change this name 1`] = `
+Object {
+  "classes": Array [
+    Object {
+      "kind": "object",
+      "props": Array [
+        Object {
+          "key": "something",
+          "kind": "property",
+          "optional": false,
+          "value": Object {
+            "kind": "string",
+          },
+        },
+      ],
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`test 1`] = `
 Object {
   "classes": Array [

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -5,7 +5,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "age",
           "kind": "property",
@@ -26,12 +26,26 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
           "optional": false,
-          "value": undefined,
+          "value": Object {
+            "kind": "generic",
+            "typeParams": Array [
+              Object {
+                "kind": "typeParam",
+                "type": Object {
+                  "kind": "boolean",
+                },
+              },
+            ],
+            "value": Object {
+              "kind": "id",
+              "name": "Array",
+            },
+          },
         },
       ],
     },
@@ -45,12 +59,34 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
           "optional": false,
-          "value": undefined,
+          "value": Object {
+            "kind": "generic",
+            "typeParams": Array [
+              Object {
+                "kind": "typeParam",
+                "type": Object {
+                  "kind": "union",
+                  "types": Array [
+                    Object {
+                      "kind": "boolean",
+                    },
+                    Object {
+                      "kind": "number",
+                    },
+                  ],
+                },
+              },
+            ],
+            "value": Object {
+              "kind": "id",
+              "name": "Array",
+            },
+          },
         },
       ],
     },
@@ -64,7 +100,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
@@ -85,7 +121,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
@@ -98,7 +134,7 @@ Object {
     },
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
@@ -119,13 +155,16 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
           "optional": false,
           "value": Object {
-            "kind": "boolean",
+            "kind": "generic",
+            "value": Object {
+              "kind": "boolean",
+            },
           },
         },
       ],
@@ -140,7 +179,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
@@ -172,7 +211,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
@@ -204,7 +243,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
@@ -233,12 +272,18 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
           "optional": false,
-          "value": undefined,
+          "value": Object {
+            "kind": "generic",
+            "value": Object {
+              "kind": "id",
+              "name": "Function",
+            },
+          },
         },
       ],
     },
@@ -252,7 +297,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
@@ -284,7 +329,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
@@ -294,7 +339,7 @@ Object {
             "parameters": Array [
               Object {
                 "kind": "object",
-                "props": Array [
+                "members": Array [
                   Object {
                     "key": "prop",
                     "kind": "property",
@@ -321,7 +366,13 @@ Object {
 exports[`flow generic class 1`] = `
 Object {
   "classes": Array [
-    undefined,
+    Object {
+      "kind": "generic",
+      "value": Object {
+        "kind": "id",
+        "name": "A",
+      },
+    },
   ],
   "kind": "program",
 }
@@ -331,20 +382,26 @@ exports[`flow import { type } 1`] = `
 Object {
   "classes": Array [
     Object {
-      "kind": "object",
-      "props": Array [
-        Object {
-          "key": "children",
-          "kind": "property",
-          "optional": false,
-          "value": Object {
-            "importKind": "type",
-            "kind": "import",
-            "moduleSpecifier": "react",
-            "name": "Node",
+      "kind": "generic",
+      "value": Object {
+        "kind": "object",
+        "members": Array [
+          Object {
+            "key": "children",
+            "kind": "property",
+            "optional": false,
+            "value": Object {
+              "kind": "generic",
+              "value": Object {
+                "importKind": "type",
+                "kind": "import",
+                "moduleSpecifier": "react",
+                "name": "Node",
+              },
+            },
           },
-        },
-      ],
+        ],
+      },
     },
   ],
   "kind": "program",
@@ -356,7 +413,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
@@ -380,7 +437,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "age",
           "kind": "property",
@@ -408,7 +465,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
@@ -429,7 +486,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
@@ -450,7 +507,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
@@ -470,25 +527,28 @@ exports[`flow type 1`] = `
 Object {
   "classes": Array [
     Object {
-      "kind": "object",
-      "props": Array [
-        Object {
-          "key": "foo",
-          "kind": "property",
-          "optional": false,
-          "value": Object {
-            "kind": "number",
+      "kind": "generic",
+      "value": Object {
+        "kind": "object",
+        "members": Array [
+          Object {
+            "key": "foo",
+            "kind": "property",
+            "optional": false,
+            "value": Object {
+              "kind": "number",
+            },
           },
-        },
-        Object {
-          "key": "bar",
-          "kind": "property",
-          "optional": false,
-          "value": Object {
-            "kind": "boolean",
+          Object {
+            "key": "bar",
+            "kind": "property",
+            "optional": false,
+            "value": Object {
+              "kind": "boolean",
+            },
           },
-        },
-      ],
+        ],
+      },
     },
   ],
   "kind": "program",
@@ -500,7 +560,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
@@ -528,15 +588,24 @@ exports[`flow type identifier 1`] = `
 Object {
   "classes": Array [
     Object {
-      "kind": "object",
-      "props": Array [
-        Object {
-          "key": "children",
-          "kind": "property",
-          "optional": false,
-          "value": undefined,
-        },
-      ],
+      "kind": "generic",
+      "value": Object {
+        "kind": "object",
+        "members": Array [
+          Object {
+            "key": "children",
+            "kind": "property",
+            "optional": false,
+            "value": Object {
+              "kind": "generic",
+              "value": Object {
+                "kind": "id",
+                "name": "Node",
+              },
+            },
+          },
+        ],
+      },
     },
   ],
   "kind": "program",
@@ -548,7 +617,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
@@ -577,7 +646,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "age",
           "kind": "property",
@@ -607,7 +676,7 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
@@ -623,53 +692,40 @@ Object {
 }
 `;
 
-exports[`new test 2 ben also fix this 1`] = `
+exports[`intersection type 1`] = `
 Object {
   "classes": Array [
     Object {
-      "kind": "object",
-      "props": Array [
+      "kind": "intersection",
+      "types": Array [
+        Object {
+          "kind": "generic",
+          "value": Object {
+            "kind": "object",
+            "members": Array [
+              Object {
+                "key": "bar",
+                "kind": "property",
+                "optional": false,
+                "value": Object {
+                  "kind": "string",
+                },
+              },
+            ],
+          },
+        },
         Object {
           "kind": "object",
-          "props": Array [
+          "members": Array [
             Object {
-              "key": "bar",
+              "key": "isDefaultChecked",
               "kind": "property",
               "optional": false,
               "value": Object {
-                "kind": "string",
+                "kind": "boolean",
               },
             },
           ],
-        },
-        Object {
-          "key": "isDefaultChecked",
-          "kind": "property",
-          "optional": false,
-          "value": Object {
-            "kind": "boolean",
-          },
-        },
-      ],
-    },
-  ],
-  "kind": "program",
-}
-`;
-
-exports[`new test ben change this name 1`] = `
-Object {
-  "classes": Array [
-    Object {
-      "kind": "object",
-      "props": Array [
-        Object {
-          "key": "something",
-          "kind": "property",
-          "optional": false,
-          "value": Object {
-            "kind": "string",
-          },
         },
       ],
     },
@@ -683,12 +739,18 @@ Object {
   "classes": Array [
     Object {
       "kind": "object",
-      "props": Array [
+      "members": Array [
         Object {
           "key": "foo",
           "kind": "property",
           "optional": true,
-          "value": undefined,
+          "value": Object {
+            "kind": "generic",
+            "value": Object {
+              "kind": "id",
+              "name": "Object",
+            },
+          },
         },
       ],
     },
@@ -719,7 +781,10 @@ Object {
     Object {
       "kind": "object",
       "props": Array [
-        undefined,
+        Object {
+          "kind": "id",
+          "name": "Array",
+        },
       ],
     },
   ],
@@ -773,7 +838,10 @@ Object {
     Object {
       "kind": "object",
       "props": Array [
-        undefined,
+        Object {
+          "kind": "id",
+          "name": "Color",
+        },
       ],
     },
   ],
@@ -790,8 +858,14 @@ Object {
         Object {
           "kind": "function",
           "parameters": Array [
-            undefined,
-            undefined,
+            Object {
+              "kind": "id",
+              "name": "string",
+            },
+            Object {
+              "kind": "id",
+              "name": "boolean",
+            },
           ],
           "returnType": Object {
             "kind": "number",
@@ -807,7 +881,10 @@ Object {
 exports[`ts interface 1`] = `
 Object {
   "classes": Array [
-    undefined,
+    Object {
+      "kind": "id",
+      "name": "ComponentProps",
+    },
   ],
   "kind": "program",
 }
@@ -963,6 +1040,49 @@ Object {
           "kind": "void",
         },
       ],
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`with spread in type annotation 1`] = `
+Object {
+  "classes": Array [
+    Object {
+      "kind": "generic",
+      "value": Object {
+        "kind": "object",
+        "members": Array [
+          Object {
+            "kind": "spread",
+            "value": Object {
+              "kind": "generic",
+              "value": Object {
+                "kind": "object",
+                "members": Array [
+                  Object {
+                    "key": "foo",
+                    "kind": "property",
+                    "optional": false,
+                    "value": Object {
+                      "kind": "string",
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          Object {
+            "key": "isDefaultChecked",
+            "kind": "property",
+            "optional": false,
+            "value": Object {
+              "kind": "boolean",
+            },
+          },
+        ],
+      },
     },
   ],
   "kind": "program",

--- a/index.js
+++ b/index.js
@@ -31,7 +31,6 @@ converters.Program = (path, context) => {
       let params = path.get('superTypeParameters').get('params');
       let props = params[0];
 
-      let updating = convert(props, context)
       result.classes.push(convert(props, context));
     },
   });

--- a/test.js
+++ b/test.js
@@ -85,6 +85,7 @@ const TESTS = [{
     }
   `
 }, {
+  skip: true,
   name: 'flow array',
   typeSystem: 'flow',
   code: `
@@ -176,6 +177,32 @@ const TESTS = [{
     }
   `
 }, {
+  only: true,
+  name: 'new test ben change this name',
+  typeSystem: 'flow',
+  code: `
+  type BaseProps = { bar: string }
+
+  class Component extends React.Component<BaseProps & {
+    isDefaultChecked: boolean,
+  }> {
+  }
+  `
+}, {
+  only: true,
+  name: 'new test 2 ben also fix this',
+  typeSystem: 'flow',
+  code: `
+  type BaseProps = { foo: string }
+  type Props = {
+    ...BaseProps,
+    isDefaultChecked: boolean,
+  }
+  class Component extends React.Component<Props> {
+  }
+  `
+}, {
+  skip: true,
   name: 'flow array union',
   typeSystem: 'flow',
   code: `
@@ -364,7 +391,6 @@ const TESTS = [{
     }
   `
 }, {
-  only: true,
   name: 'test',
   typeSystem: 'flow',
   code: `

--- a/test.js
+++ b/test.js
@@ -85,7 +85,6 @@ const TESTS = [{
     }
   `
 }, {
-  skip: true,
   name: 'flow array',
   typeSystem: 'flow',
   code: `
@@ -177,8 +176,7 @@ const TESTS = [{
     }
   `
 }, {
-  only: true,
-  name: 'new test ben change this name',
+  name: 'intersection type',
   typeSystem: 'flow',
   code: `
   type BaseProps = { bar: string }
@@ -189,8 +187,7 @@ const TESTS = [{
   }
   `
 }, {
-  only: true,
-  name: 'new test 2 ben also fix this',
+  name: 'with spread in type annotation',
   typeSystem: 'flow',
   code: `
   type BaseProps = { foo: string }
@@ -202,7 +199,6 @@ const TESTS = [{
   }
   `
 }, {
-  skip: true,
   name: 'flow array union',
   typeSystem: 'flow',
   code: `


### PR DESCRIPTION
- The `props` property of `kind: object` has been renamed to `method`. THIS IS A MASSIVE BREAKING CHANGE
- added `typeParameters` converter
- rewrote genericTypeAnnotation to return `kind: generic` THIS IS A MASSIVE BREAKING CHANGE
- added `ObjectTypeSpreadProperty` converter
- stopped adding converters that were accepting not node.