### PR TITLE
Adding defaultProp support for React Elements

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -1519,6 +1519,253 @@ Object {
 }
 `;
 
+exports[`test defaultProp as JSXElement 1`] = `
+Object {
+  "classes": Array [
+    Object {
+      "kind": "object",
+      "members": Array [
+        Object {
+          "default": Object {
+            "kind": "JSXElement",
+            "value": Object {
+              "attributes": Array [
+                Object {
+                  "kind": "JSXAttribute",
+                  "name": Object {
+                    "kind": "JSXIdentifier",
+                    "value": "name",
+                  },
+                  "value": Object {
+                    "kind": "JSXExpressionContainer",
+                    "value": Object {
+                      "kind": "string",
+                      "value": "test icon",
+                    },
+                  },
+                },
+              ],
+              "kind": "JSXOpeningElement",
+              "name": Object {
+                "kind": "JSXIdentifier",
+                "value": "Icon",
+              },
+            },
+          },
+          "key": "a",
+          "kind": "property",
+          "optional": false,
+          "value": Object {
+            "kind": "generic",
+            "value": Object {
+              "importKind": "type",
+              "kind": "import",
+              "moduleSpecifier": "react",
+              "name": "Node",
+            },
+          },
+        },
+      ],
+      "name": Object {
+        "kind": "id",
+        "name": "Component",
+        "type": null,
+      },
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`test defaultProp as JSXElement with JSXExpressionContainer 1`] = `
+Object {
+  "classes": Array [
+    Object {
+      "kind": "object",
+      "members": Array [
+        Object {
+          "default": Object {
+            "kind": "JSXElement",
+            "value": Object {
+              "attributes": Array [
+                Object {
+                  "kind": "JSXAttribute",
+                  "name": Object {
+                    "kind": "JSXIdentifier",
+                    "value": "name",
+                  },
+                  "value": Object {
+                    "kind": "JSXExpressionContainer",
+                    "value": Object {
+                      "kind": "string",
+                      "value": "test icon",
+                    },
+                  },
+                },
+              ],
+              "kind": "JSXOpeningElement",
+              "name": Object {
+                "kind": "JSXIdentifier",
+                "value": "Icon",
+              },
+            },
+          },
+          "key": "a",
+          "kind": "property",
+          "optional": false,
+          "value": Object {
+            "kind": "generic",
+            "value": Object {
+              "importKind": "type",
+              "kind": "import",
+              "moduleSpecifier": "react",
+              "name": "Node",
+            },
+          },
+        },
+      ],
+      "name": Object {
+        "kind": "id",
+        "name": "Component",
+        "type": null,
+      },
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`test defaultProp as JSXElement with member expression 1`] = `
+Object {
+  "classes": Array [
+    Object {
+      "kind": "object",
+      "members": Array [
+        Object {
+          "default": Object {
+            "kind": "JSXElement",
+            "value": Object {
+              "attributes": Array [
+                Object {
+                  "kind": "JSXAttribute",
+                  "name": Object {
+                    "kind": "JSXIdentifier",
+                    "value": "name",
+                  },
+                  "value": Object {
+                    "kind": "JSXExpressionContainer",
+                    "value": Object {
+                      "kind": "string",
+                      "value": "test icon",
+                    },
+                  },
+                },
+              ],
+              "kind": "JSXOpeningElement",
+              "name": Object {
+                "kind": "JSXMemberExpression",
+                "object": Object {
+                  "kind": "JSXIdentifier",
+                  "value": "componentObj",
+                },
+                "property": Object {
+                  "kind": "JSXIdentifier",
+                  "value": "Icon",
+                },
+              },
+            },
+          },
+          "key": "a",
+          "kind": "property",
+          "optional": false,
+          "value": Object {
+            "kind": "generic",
+            "value": Object {
+              "importKind": "type",
+              "kind": "import",
+              "moduleSpecifier": "react",
+              "name": "Node",
+            },
+          },
+        },
+      ],
+      "name": Object {
+        "kind": "id",
+        "name": "Component",
+        "type": null,
+      },
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`test defaultProp as JSXElement with multiple props 1`] = `
+Object {
+  "classes": Array [
+    Object {
+      "kind": "object",
+      "members": Array [
+        Object {
+          "default": Object {
+            "kind": "JSXElement",
+            "value": Object {
+              "attributes": Array [
+                Object {
+                  "kind": "JSXAttribute",
+                  "name": Object {
+                    "kind": "JSXIdentifier",
+                    "value": "name",
+                  },
+                  "value": Object {
+                    "kind": "string",
+                    "value": "test icon",
+                  },
+                },
+                Object {
+                  "kind": "JSXAttribute",
+                  "name": Object {
+                    "kind": "JSXIdentifier",
+                    "value": "iconType",
+                  },
+                  "value": Object {
+                    "kind": "string",
+                    "value": "avatar",
+                  },
+                },
+              ],
+              "kind": "JSXOpeningElement",
+              "name": Object {
+                "kind": "JSXIdentifier",
+                "value": "Icon",
+              },
+            },
+          },
+          "key": "a",
+          "kind": "property",
+          "optional": false,
+          "value": Object {
+            "kind": "generic",
+            "value": Object {
+              "importKind": "type",
+              "kind": "import",
+              "moduleSpecifier": "react",
+              "name": "Node",
+            },
+          },
+        },
+      ],
+      "name": Object {
+        "kind": "id",
+        "name": "Component",
+        "type": null,
+      },
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`test get defaultProps 1`] = `
 Object {
   "classes": Array [

--- a/index.js
+++ b/index.js
@@ -122,6 +122,51 @@ converters.SpreadElement = (path, context) => {
   };
 };
 
+converters.JSXAttribute = (path, context) => {
+  return {
+    kind: 'JSXAttribute',
+    name: convert(path.get('name'), context),
+    value: convert(path.get('value'), context),
+  }
+}
+
+converters.JSXExpressionContainer = (path, context) => {
+  return {
+    kind: 'JSXExpressionContainer',
+    value: convert(path.get('expression'), context),
+  }
+}
+
+converters.JSXElement = (path, context) => {
+  return {
+    kind: 'JSXElement',
+    value: convert(path.get('openingElement'), context),
+  }
+}
+
+converters.JSXIdentifier = (path,context) => {
+  return {
+    kind: 'JSXIdentifier',
+    value: path.node.name,
+  }
+}
+
+converters.JSXMemberExpression = (path, context) => {
+  return {
+    kind: 'JSXMemberExpression',
+    object: convert(path.get("object"), context),
+    property: convert(path.get("property"), context),
+  }
+}
+
+
+converters.JSXOpeningElement = (path, context) => {
+  return {
+    kind: 'JSXOpeningElement',
+    name: convert(path.get('name'), context),
+    attributes: path.get('attributes').map(item => convert(item, context)),
+  };
+}
 converters.ClassProperty = (path, context) => {
   return {
     kind: "property",

--- a/test.js
+++ b/test.js
@@ -449,6 +449,58 @@ const TESTS = [
   `
   },
   {
+    name: "test defaultProp as JSXElement",
+    typeSystem: "flow",
+    code: `
+      import type { Node } from 'react';
+      const Icon = <div></div>
+      class Component extends React.Component<{a: Node }> {
+        defaultProps = {
+          a: <Icon name={"test icon"}/>
+        }
+      }
+    `
+  },
+  {
+    name: "test defaultProp as JSXElement with member expression",
+    typeSystem: "flow",
+    code: `
+    import type { Node } from 'react';
+    const Icon = <div></div>
+    const componentObj = { Icon }
+    class Component extends React.Component<{a: Node }> {
+      defaultProps = {
+        a: <componentObj.Icon name={"test icon"}/>
+      }
+    }
+    `
+  },
+  {
+    name: "test defaultProp as JSXElement with multiple props",
+    typeSystem: "flow",
+    code: `
+      import type { Node } from 'react';
+      const Icon = <div></div>
+      class Component extends React.Component<{a: Node}>{
+        defaultProps = {
+          a: <Icon name="test icon" iconType="avatar" />
+        }
+      }
+    `
+  }, {
+      name: "test defaultProp as JSXElement with JSXExpressionContainer",
+      typeSystem: "flow",
+      code: `
+        import type { Node } from 'react';
+        const Icon = <div></div>
+        class Component extends React.Component<{a: Node}>{
+          defaultProps = {
+            a: <Icon name={"test icon"} />
+          }
+        }
+      `
+    },
+  {
     name: "spread element ",
     typeSystem: "flow",
     code: `


### PR DESCRIPTION
Adding defaultProp support for React Elements. The following converters have been added: 
- JSXElement
- JSXOpeningElement
- JSXMemberExpression
- JSXIdentifier
- JSXExpressionContainer 
- JSXAttribute 